### PR TITLE
Added artifact uploading instructions for github actions.

### DIFF
--- a/.github/workflows/renpycompile.yml
+++ b/.github/workflows/renpycompile.yml
@@ -30,3 +30,8 @@ jobs:
       env:
         SDL_AUDIODRIVER: dummy
         SDL_VIDEODRIVER: dummy
+    - name: Upload VN artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: distributions
+        path: friendsim-1.0-dists

--- a/.github/workflows/renpycompile.yml
+++ b/.github/workflows/renpycompile.yml
@@ -34,4 +34,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: distributions
-        path: friendsim-1.0-dists
+        path: homestuck-ngp-0.0.1-dists


### PR DESCRIPTION
Quick update to add artifact uploading for github actions. Distros should now automatically be downloadable after build step completes.